### PR TITLE
Scaffold SwiftUI macOS EDF viewer foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "EDFViewerMacOS",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "EDFViewerMacOS", targets: ["EDFViewerMacOS"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "EDFViewerMacOS",
+            path: "Sources/EDFViewerMacOS"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # EDFViewer-MacOS
-EDFBrowser-MacOS
+
+A macOS-focused EDF/BDF viewer scaffold using **SwiftUI** for rendering and a clean core boundary intended for **EDFlib** (`edflib.c/.h`) integration.
+
+## What is included
+
+- Swift Package project layout so the repository is runnable and versionable.
+- SwiftUI app shell (macOS) with:
+  - File open flow (`.edf`, `.bdf`)
+  - Channel list panel
+  - Waveform rendering area
+  - Zoom and pan controls
+- Min/Max downsampling renderer (`Canvas`) for responsive waveform drawing.
+- `EDFService` abstraction:
+  - `MockEDFService` for immediate UI bring-up
+  - `EDFLibService` placeholder where real C interop goes
+
+## Current status
+
+This repository now has a practical macOS app skeleton, but real EDF/BDF decode is still a TODO in `EDFLibService`.
+
+That design keeps UI and data-access cleanly separated, so once EDFlib is wired in, the SwiftUI surface should require little-to-no restructuring.
+
+## Run (in this repo)
+
+```bash
+swift run EDFViewerMacOS
+```
+
+- On **macOS**, this starts the SwiftUI app.
+- On **Linux CI/dev containers**, it prints a friendly message because SwiftUI/AppKit are macOS-only.
+
+## Wiring EDFlib in Xcode (recommended next step)
+
+1. Add `edflib.c` + `edflib.h` to your app target.
+2. Create a bridging header (if using an Xcode app target) and import `edflib.h`.
+3. Implement `EDFLibService` methods:
+   - open/close file handle
+   - enumerate channels
+   - read samples for a viewport
+4. Keep the downsampling logic in Swift (already present), or move it to C if profiling justifies it.
+
+## Suggested roadmap
+
+1. Implement `EDFLibService` open + channel metadata.
+2. Implement random/semi-random access sample reads for viewport windows.
+3. Add annotation lane and cursor tools.
+4. Add export pipeline (PNG/SVG/CSV segments).

--- a/Sources/EDFViewerMacOS/AppMain.swift
+++ b/Sources/EDFViewerMacOS/AppMain.swift
@@ -1,0 +1,13 @@
+#if canImport(SwiftUI) && os(macOS)
+import SwiftUI
+
+@main
+struct EDFViewerMacOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ViewerRootView()
+        }
+        .windowResizability(.contentSize)
+    }
+}
+#endif

--- a/Sources/EDFViewerMacOS/Core/Downsampler.swift
+++ b/Sources/EDFViewerMacOS/Core/Downsampler.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum Downsampler {
+    static func minMax(_ samples: [Float], bucketCount: Int) -> MinMaxSeries {
+        guard !samples.isEmpty, bucketCount > 0 else {
+            return MinMaxSeries(mins: [], maxs: [])
+        }
+
+        let step = max(1, samples.count / bucketCount)
+        var mins: [Float] = []
+        var maxs: [Float] = []
+        mins.reserveCapacity(bucketCount)
+        maxs.reserveCapacity(bucketCount)
+
+        var i = 0
+        while i < samples.count {
+            let end = min(samples.count, i + step)
+            var mn = samples[i]
+            var mx = samples[i]
+            if end - i > 1 {
+                for sample in samples[(i + 1)..<end] {
+                    mn = min(mn, sample)
+                    mx = max(mx, sample)
+                }
+            }
+            mins.append(mn)
+            maxs.append(mx)
+            i = end
+        }
+
+        return MinMaxSeries(mins: mins, maxs: maxs)
+    }
+}

--- a/Sources/EDFViewerMacOS/Core/EDFModels.swift
+++ b/Sources/EDFViewerMacOS/Core/EDFModels.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct EDFChannelInfo: Identifiable, Hashable {
+    public let id: Int
+    public let label: String
+    public let unit: String
+    public let sampleRate: Double
+
+    public init(id: Int, label: String, unit: String, sampleRate: Double) {
+        self.id = id
+        self.label = label
+        self.unit = unit
+        self.sampleRate = sampleRate
+    }
+}
+
+public struct EDFViewport: Hashable {
+    public var startSecond: Double
+    public var duration: Double
+
+    public init(startSecond: Double, duration: Double) {
+        self.startSecond = max(0, startSecond)
+        self.duration = max(0.2, duration)
+    }
+}
+
+public struct MinMaxSeries: Hashable {
+    public let mins: [Float]
+    public let maxs: [Float]
+
+    public init(mins: [Float], maxs: [Float]) {
+        self.mins = mins
+        self.maxs = maxs
+    }
+}

--- a/Sources/EDFViewerMacOS/Core/EDFService.swift
+++ b/Sources/EDFViewerMacOS/Core/EDFService.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+protocol EDFService {
+    var fileName: String { get }
+    var channelCount: Int { get }
+    var totalDuration: Double { get }
+
+    func channelInfo(at index: Int) throws -> EDFChannelInfo
+    func readSamples(channel index: Int, viewport: EDFViewport) throws -> [Float]
+}
+
+enum EDFServiceError: LocalizedError {
+    case invalidChannel
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidChannel:
+            return "Invalid channel index"
+        }
+    }
+}
+
+/// Placeholder implementation to keep the project runnable before wiring EDFlib.
+final class MockEDFService: EDFService {
+    let fileName: String
+    let channelCount: Int
+    let totalDuration: Double
+
+    init(fileName: String = "Preview.edf", channelCount: Int = 8, totalDuration: Double = 120) {
+        self.fileName = fileName
+        self.channelCount = channelCount
+        self.totalDuration = totalDuration
+    }
+
+    func channelInfo(at index: Int) throws -> EDFChannelInfo {
+        guard index >= 0, index < channelCount else {
+            throw EDFServiceError.invalidChannel
+        }
+
+        return EDFChannelInfo(
+            id: index,
+            label: "Ch\(index + 1)",
+            unit: "uV",
+            sampleRate: 256
+        )
+    }
+
+    func readSamples(channel index: Int, viewport: EDFViewport) throws -> [Float] {
+        let info = try channelInfo(at: index)
+        let count = max(1, Int(viewport.duration * info.sampleRate))
+
+        return (0..<count).map { sampleIndex in
+            let t = viewport.startSecond + Double(sampleIndex) / info.sampleRate
+            let base = sin(2 * Double.pi * (1.5 + Double(index) * 0.2) * t)
+            let modulation = 0.35 * sin(2 * Double.pi * 0.2 * t)
+            return Float((base + modulation) * 100)
+        }
+    }
+}
+
+/// Adapter shell where EDFlib integration should be implemented.
+///
+/// Replace method bodies with direct C calls from `edflib.h` once `edflib.c/.h`
+/// are vendored into the Xcode project.
+final class EDFLibService: EDFService {
+    let fileName: String
+    let channelCount: Int
+    let totalDuration: Double
+
+    init(url: URL) throws {
+        // TODO: Open the EDF/BDF file through EDFlib.
+        self.fileName = url.lastPathComponent
+        self.channelCount = 0
+        self.totalDuration = 0
+    }
+
+    func channelInfo(at index: Int) throws -> EDFChannelInfo {
+        throw EDFServiceError.invalidChannel
+    }
+
+    func readSamples(channel index: Int, viewport: EDFViewport) throws -> [Float] {
+        _ = viewport
+        throw EDFServiceError.invalidChannel
+    }
+}

--- a/Sources/EDFViewerMacOS/Core/ViewerViewModel.swift
+++ b/Sources/EDFViewerMacOS/Core/ViewerViewModel.swift
@@ -1,0 +1,68 @@
+#if canImport(SwiftUI) && os(macOS)
+import Foundation
+import SwiftUI
+
+@MainActor
+final class ViewerViewModel: ObservableObject {
+    @Published var channels: [EDFChannelInfo] = []
+    @Published var selectedChannel: EDFChannelInfo?
+    @Published var viewport = EDFViewport(startSecond: 0, duration: 10)
+    @Published var waveform = MinMaxSeries(mins: [], maxs: [])
+    @Published var status = "Open an EDF/BDF file to start"
+
+    private var service: EDFService = MockEDFService()
+
+    init() {
+        loadChannelList()
+        refreshWaveform(pixelWidth: 1200)
+        status = "Loaded mock signal. Use File > Open to wire a real EDF file via EDFlib."
+    }
+
+    func load(url: URL) {
+        do {
+            service = try EDFLibService(url: url)
+            viewport = EDFViewport(startSecond: 0, duration: 10)
+            loadChannelList()
+            refreshWaveform(pixelWidth: 1200)
+            status = "Loaded \(service.fileName)"
+        } catch {
+            status = "Failed to load \(url.lastPathComponent): \(error.localizedDescription)"
+        }
+    }
+
+    func pan(seconds: Double) {
+        let maxStart = max(0, service.totalDuration - viewport.duration)
+        viewport.startSecond = min(max(0, viewport.startSecond + seconds), maxStart)
+        refreshWaveform(pixelWidth: 1200)
+    }
+
+    func zoom(factor: Double) {
+        let current = viewport.duration
+        let next = min(max(0.5, current * factor), max(0.5, service.totalDuration))
+        viewport.duration = next
+        pan(seconds: 0)
+    }
+
+    func refreshWaveform(pixelWidth: Int) {
+        guard let channel = selectedChannel else {
+            waveform = MinMaxSeries(mins: [], maxs: [])
+            return
+        }
+
+        do {
+            let raw = try service.readSamples(channel: channel.id, viewport: viewport)
+            waveform = Downsampler.minMax(raw, bucketCount: max(64, pixelWidth))
+        } catch {
+            waveform = MinMaxSeries(mins: [], maxs: [])
+            status = "Read failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func loadChannelList() {
+        channels = (0..<service.channelCount).compactMap { index in
+            try? service.channelInfo(at: index)
+        }
+        selectedChannel = channels.first
+    }
+}
+#endif

--- a/Sources/EDFViewerMacOS/UI/ViewerRootView.swift
+++ b/Sources/EDFViewerMacOS/UI/ViewerRootView.swift
@@ -1,0 +1,65 @@
+#if canImport(SwiftUI) && os(macOS)
+import SwiftUI
+import AppKit
+
+struct ViewerRootView: View {
+    @StateObject private var viewModel = ViewerViewModel()
+
+    var body: some View {
+        NavigationSplitView {
+            List(viewModel.channels, selection: Binding(
+                get: { viewModel.selectedChannel?.id },
+                set: { newValue in
+                    if let id = newValue {
+                        viewModel.selectedChannel = viewModel.channels.first(where: { $0.id == id })
+                        viewModel.refreshWaveform(pixelWidth: 1200)
+                    }
+                })
+            ) { channel in
+                VStack(alignment: .leading) {
+                    Text(channel.label)
+                    Text("\(Int(channel.sampleRate)) Hz • \(channel.unit)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("Channels")
+        } detail: {
+            VStack(spacing: 12) {
+                HStack {
+                    Button("Open EDF/BDF") { openPanel() }
+                    Spacer()
+                    Button("- Zoom") { viewModel.zoom(factor: 1.5) }
+                    Button("+ Zoom") { viewModel.zoom(factor: 0.67) }
+                    Button("←") { viewModel.pan(seconds: -viewModel.viewport.duration * 0.2) }
+                    Button("→") { viewModel.pan(seconds: viewModel.viewport.duration * 0.2) }
+                }
+
+                WaveformMinMaxView(waveform: viewModel.waveform)
+                    .frame(minHeight: 300)
+
+                Text(viewModel.status)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding()
+            .navigationTitle("EDF Viewer")
+        }
+    }
+
+    private func openPanel() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedFileTypes = ["edf", "bdf"]
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else {
+                return
+            }
+            viewModel.load(url: url)
+        }
+    }
+}
+#endif

--- a/Sources/EDFViewerMacOS/UI/WaveformMinMaxView.swift
+++ b/Sources/EDFViewerMacOS/UI/WaveformMinMaxView.swift
@@ -1,0 +1,34 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct WaveformMinMaxView: View {
+    let waveform: MinMaxSeries
+
+    var body: some View {
+        Canvas { context, size in
+            guard !waveform.mins.isEmpty, waveform.mins.count == waveform.maxs.count else {
+                return
+            }
+
+            let globalMin = waveform.mins.min() ?? -1
+            let globalMax = waveform.maxs.max() ?? 1
+            let range = max(1e-6, globalMax - globalMin)
+
+            let xStep = size.width / CGFloat(waveform.mins.count)
+            var path = Path()
+
+            for idx in waveform.mins.indices {
+                let x = CGFloat(idx) * xStep
+                let minY = size.height - CGFloat((waveform.mins[idx] - globalMin) / range) * size.height
+                let maxY = size.height - CGFloat((waveform.maxs[idx] - globalMin) / range) * size.height
+                path.move(to: CGPoint(x: x, y: minY))
+                path.addLine(to: CGPoint(x: x, y: maxY))
+            }
+
+            context.stroke(path, with: .color(.accentColor), lineWidth: 1)
+        }
+        .background(Color.black.opacity(0.03))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+#endif

--- a/Sources/EDFViewerMacOS/main.swift
+++ b/Sources/EDFViewerMacOS/main.swift
@@ -1,0 +1,3 @@
+#if !os(macOS)
+print("EDFViewerMacOS SwiftUI app builds on macOS. This Linux entry point exists for CI checks.")
+#endif


### PR DESCRIPTION
### Motivation

- Provide a clean, buildable macOS-first SwiftUI scaffold for viewing EDF/BDF files so UI and data-access can be iterated independently.  
- Keep a clear boundary so EDFlib (`edflib.c/.h`) can be vendored and wired in later without changing UI code.  
- Ensure responsive waveform rendering for large signals by designing a min/max downsampling pipeline up front.

### Description

- Added a Swift Package manifest (`Package.swift`) and an executable target rooted at `Sources/EDFViewerMacOS` to make the project buildable and versionable.  
- Implemented core models and helpers in `Core/` including `EDFChannelInfo`, `EDFViewport`, `MinMaxSeries`, and a `Downsampler.minMax` function for min/max downsampling.  
- Introduced an `EDFService` abstraction with a runnable `MockEDFService` and a placeholder `EDFLibService` where direct EDFlib C interop should be implemented.  
- Built a macOS SwiftUI UI shell (`ViewerRootView`, `WaveformMinMaxView`) and a `ViewerViewModel` to drive selection, viewport, and waveform refresh flows, plus a macOS app entry (`AppMain.swift`) and a Linux fallback entry (`main.swift`).  
- Updated `README.md` with architecture notes, run instructions, and a concrete roadmap for wiring EDFlib and next features.

### Testing

- Ran `swift build` and the build completed successfully.  
- Ran `swift run EDFViewerMacOS` and the run completed successfully; on non-macOS targets the binary prints a CI-friendly fallback message indicating the SwiftUI app is macOS-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996068732948321b371d041f8727ba1)